### PR TITLE
feat: [PowerSync] Add metadata tracking

### DIFF
--- a/.changeset/some-wombats-rest.md
+++ b/.changeset/some-wombats-rest.md
@@ -1,0 +1,39 @@
+---
+"@tanstack/powersync-db-collection": patch
+---
+
+Added support for tracking collection operation metadata in PowerSync CrudEntry operations.
+
+```typescript
+// Schema config
+const APP_SCHEMA = new Schema({
+  documents: new Table(
+    {
+      name: column.text,
+      author: column.text,
+      created_at: column.text,
+    },
+    {
+      // Metadata tracking must be enabled on the PowerSync table
+      trackMetadata: true,
+    }
+  ),
+})
+
+// ... Other config
+
+// Collection operations which specify metadata
+await collection.insert(
+  {
+    id,
+    name: `document`,
+    author: `Foo`,
+  },
+  // The string version of this will be present in PowerSync `CrudEntry`s during uploads
+  {
+    metadata: {
+      extraInfo: "Info",
+    },
+  }
+)
+```

--- a/packages/powersync-db-collection/src/definitions.ts
+++ b/packages/powersync-db-collection/src/definitions.ts
@@ -246,6 +246,11 @@ export type PowerSyncCollectionMeta<TTable extends Table = Table> = {
    * Serializes a collection value to the SQLite type
    */
   serializeValue: (value: any) => ExtractedTable<TTable>
+
+  /**
+   * Whether the PowerSync table tracks metadata.
+   */
+  metadataIsTracked: boolean
 }
 
 /**

--- a/packages/powersync-db-collection/src/powersync.ts
+++ b/packages/powersync-db-collection/src/powersync.ts
@@ -242,7 +242,7 @@ export function powerSyncCollectionOptions<
   // The collection output type
   type OutputType = InferPowerSyncOutputType<TTable, TSchema>
 
-  const { viewName } = table
+  const { viewName, trackMetadata: metadataIsTracked } = table
 
   /**
    * Deserializes data from the incoming sync stream
@@ -459,6 +459,7 @@ export function powerSyncCollectionOptions<
       getMeta: () => ({
         tableName: viewName,
         trackedTableName,
+        metadataIsTracked,
         serializeValue: (value) =>
           serializeForSQLite(
             value,


### PR DESCRIPTION
[This is just a temporary PR for internal comment]

closes https://github.com/TanStack/db/issues/959

## Summary

- Add support for tracking collection operation metadata in PowerSync `CrudEntry` records
- When `trackMetadata: true` is enabled on a PowerSync table, metadata passed to `insert`, `update`, and `delete` operations is persisted and available during upload processing

## Description

This PR enables PowerSync collections to track custom metadata alongside CRUD operations. This is useful for passing additional context about mutations to the backend, such as audit information, operation sources, or custom processing hints.

### Key Changes

**Metadata Persistence:**

- Leverages PowerSync's built-in `trackMetadata` table option to persist metadata with CRUD operations
- Insert and update operations populate the `_metadata` column when metadata is provided
- Delete operations with metadata use PowerSync's soft-delete pattern (`_deleted = TRUE`) to preserve metadata

**Validation & Warnings:**

- Added `metadataIsTracked` to `PowerSyncCollectionMeta` to track table configuration
- Logs a warning if metadata is provided to a collection whose table doesn't have `trackMetadata: true`

**Developer Experience:**

- Added documentation section covering enablement, usage in operations, and accessing metadata during upload

### Usage

```typescript
// Enable in schema
const APP_SCHEMA = new Schema({
  documents: new Table(
    { name: column.text, author: column.text },
    { trackMetadata: true }
  ),
})

// Use in operations
await collection.insert(
  { id, name: "doc", author: "Jane" },
  { metadata: { source: "web-app", userId: "user-123" } }
)
```

**Accessing Metadata During Upload:**

```typescript
import { CrudEntry } from "@powersync/web"

class Connector implements PowerSyncBackendConnector {
  // ...

  async uploadData(database: AbstractPowerSyncDatabase) {
    const batch = await database.getCrudBatch()
    if (!batch) return

    for (const entry of batch.crud) {
      console.log("Operation:", entry.op) // PUT, PATCH, DELETE
      console.log("Table:", entry.table)
      console.log("Data:", entry.opData)
      console.log("Metadata:", entry.metadata) // Custom metadata (stringified)

      // Parse metadata if needed
      if (entry.metadata) {
        const meta = JSON.parse(entry.metadata)
        console.log("Source:", meta.source)
        console.log("User ID:", meta.userId)
      }

      // Process the operation with the backend...
    }

    await batch.complete()
  }
}
```
